### PR TITLE
Fix upper bound for organizational-unit-name

### DIFF
--- a/docs/BR.md
+++ b/docs/BR.md
@@ -3055,7 +3055,7 @@ Table: Encoding and Order Requirements for Selected Attributes
 | `organizationName`       | `2.5.4.10` | [RFC 5280](https://tools.ietf.org/html/rfc5280) | MUST use `UTF8String` or `PrintableString` | 64 |
 | `surname`                | `2.5.4.4`  | [RFC 5280](https://tools.ietf.org/html/rfc5280) | MUST use `UTF8String` or `PrintableString` | 64[^surname_givenname] |
 | `givenName`              | `2.5.4.42` | [RFC 5280](https://tools.ietf.org/html/rfc5280) | MUST use `UTF8String` or `PrintableString` | 64[^surname_givenname] |
-| `organizationalUnitName` | `2.5.4.11` | [RFC 5280](https://tools.ietf.org/html/rfc5280) | MUST use `UTF8String` or `PrintableString` | 32 |
+| `organizationalUnitName` | `2.5.4.11` | [RFC 5280](https://tools.ietf.org/html/rfc5280) | MUST use `UTF8String` or `PrintableString` | 64 |
 | `commonName`             | `2.5.4.3`  | [RFC 5280](https://tools.ietf.org/html/rfc5280) | MUST use `UTF8String` or `PrintableString` | 64 |
 
 [^surname_givenname]: **Note**: Although RFC 5280 specifies the upper bound as 32,768 characters, this was a transcription error from X.520 (08/2005). The effective (interoperable) upper bound is 64 characters.


### PR DESCRIPTION
[RFC 5280](https://www.rfc-editor.org/rfc/rfc5280#:~:text=ub%2Dorganizational%2Dunit%2Dname%20INTEGER%20%3A%3A%3D%2064) defines 64 characters as the upper bound for ub-organizational-unit-name.

Adding a correction to @aarongable's branch with the eventual plans of having that merged into the existing PR.